### PR TITLE
Updated to use latest YQL tables

### DIFF
--- a/src/main/java/io/pivotal/quotes/service/QuoteService.java
+++ b/src/main/java/io/pivotal/quotes/service/QuoteService.java
@@ -40,19 +40,16 @@ public class QuoteService {
 	protected String company_url;
 
 	@Value("${pivotal.quotes.yahoo_rest_query}")
-	protected String yahoo_url = "https://query.yahooapis.com/v1/public/yql?q=select * from yahoo.finance.quotes where symbol in ('{symbol}')&format={fmt}&env={env}";
-
-	// @Value("${pivotal.quotes.yahoo_query}")
-	// protected String QID =
-	// "select * from yahoo.finance.quotes where symbol in ";
+	protected String yahoo_url = "https://query.yahooapis.com/v1/public/yql?q=use \"{env}\" as quotes; select * from quotes where symbol in ('{symbol}')&format={fmt}";
 
 	@Value("${pivotal.quotes.yahoo_env}")
-	protected String ENV = "http://datatables.org/alltables.env";
+	protected String ENV = "https://raw.githubusercontent.com/yql/yql-tables/master/yahoo/finance/yahoo.finance.quotes.xml";
 
 	public static final String FMT = "json";
 
 	private static final Logger logger = LoggerFactory
 			.getLogger(QuoteService.class);
+
 
 	/*
 	 * cannot autowire as don't want ribbon here.
@@ -128,8 +125,9 @@ public class QuoteService {
 	public List<Quote> getQuotes(String symbols) {
 		logger.debug("retrieving multiple quotes for: "
 				+ symbols);
+
 		YahooQuoteResponse response = restTemplate.getForObject(yahoo_url,
-				YahooQuoteResponse.class, symbols, FMT, ENV);
+				YahooQuoteResponse.class, ENV, symbols, FMT);
 		logger.debug("Got response: " + response);
 		List<Quote> quotes = response
 				.getResults()

--- a/src/test/java/io/pivotal/quotes/configuration/TestConfiguration.java
+++ b/src/test/java/io/pivotal/quotes/configuration/TestConfiguration.java
@@ -30,7 +30,7 @@ public class TestConfiguration {
 	public static final String COMPANY_EXCHANGE = "NASDAQ";
 	public static final String NULL_QUOTE_SYMBOL = "LALALALA";
 	
-	public static final String QUOTE_SYMBOLS = "EMC,IBM";
+	public static final String QUOTE_SYMBOLS = "GOOGL,IBM";
 	/*
 	 * {"Status":"SUCCESS","Name":"EMC Corp","Symbol":"EMC","LastPrice":26.135,
 	 * "Change":0.00500000000000256,"ChangePercent":0.0191350937619692,

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,5 +3,5 @@ pivotal:
     quotes_url: http://dev.markitondemand.com/Api/v2/Quote/json?symbol={symbol}
     quotes_url2: http://globalquotes.xignite.com/v3/xGlobalQuotes.json/GetGlobalDelayedQuote?IdentifierType=Symbol&Identifier={symbol}&_token=5C00193922334CF2BE564F76D2E233CF
     companies_url: http://dev.markitondemand.com/Api/v2/Lookup/json?input={name}
-    yahoo_rest_query: https://query.yahooapis.com/v1/public/yql?q=select * from yahoo.finance.quotes where symbol in ('{symbol}')&format={fmt}&env={env}
-    yahoo_env: http://datatables.org/alltables.env
+    yahoo_rest_query: https://query.yahooapis.com/v1/public/yql?q=use "{env}" as quotes;select * from quotes where symbol in ('{symbol}')&format={fmt}
+    yahoo_env: https://raw.githubusercontent.com/yql/yql-tables/master/yahoo/finance/yahoo.finance.quotes.xml

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,5 +3,5 @@ pivotal:
     quotes_url: http://dev.markitondemand.com/Api/v2/Quote/json?symbol={symbol}
     quotes_url2: http://globalquotes.xignite.com/v3/xGlobalQuotes.json/GetGlobalDelayedQuote?IdentifierType=Symbol&Identifier={symbol}&_token=5C00193922334CF2BE564F76D2E233CF
     companies_url: http://dev.markitondemand.com/Api/v2/Lookup/json?input={name}
-    yahoo_rest_query: https://query.yahooapis.com/v1/public/yql?q=select * from yahoo.finance.quotes where symbol in ('{symbol}')&format={fmt}&env={env}
-    yahoo_env: http://datatables.org/alltables.env
+    yahoo_rest_query: https://query.yahooapis.com/v1/public/yql?q=use "{env}" as quotes;select * from quotes where symbol in ('{symbol}')&format={fmt}
+    yahoo_env: https://raw.githubusercontent.com/yql/yql-tables/master/yahoo/finance/yahoo.finance.quotes.xml


### PR DESCRIPTION
Uses the [latest YQL tables](https://raw.githubusercontent.com/yql/yql-tables/master/yahoo/finance/yahoo.finance.quotes.xml) and fixes compatibility with the Yahoo Stock API. Also uses Google stock instead of EMC which no longer exists